### PR TITLE
Mark InfiniteShooter as EOL

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+    "end-of-life": "This game is no longer maintained, and the associated source code repository appears to have been deleted by the developers."
+}


### PR DESCRIPTION
> This game is no longer maintained, and the associated source code repository appears to have been deleted by the developers.